### PR TITLE
Fix pagination for author content retrieval by replacing recursion with an iterative, non-recursive approach to prevent stack overflow.

### DIFF
--- a/contracts/Truth-Chain.clar
+++ b/contracts/Truth-Chain.clar
@@ -147,3 +147,174 @@
 (define-read-only (get-content-hash-at-index (author principal) (index uint))
   (map-get? author-content-by-index { author: author, index: index })
 )
+
+;; Get author content with pagination - fixed non-recursive approach
+;; @param author: Stacks address of content creator
+;; @param page: Page number (0-based)
+;; @param page-size: Number of items per page (max 20)
+;; @returns: List of content hashes for the requested page
+(define-read-only (get-author-content-paged 
+                    (author principal) 
+                    (page uint) 
+                    (page-size uint))
+  (let
+    (
+      ;; Limit page size to reasonable amount to avoid stack overflows
+      (limited-page-size (if (> page-size u20) u20 page-size))
+      (author-record (default-to { content-count: u0, last-activity: u0 } 
+                       (map-get? author-content { author: author })))
+      (content-count (get content-count author-record))
+      (start-index (* page limited-page-size))
+    )
+    
+    ;; Check if requested page is valid
+    (if (>= start-index content-count)
+      (ok (list))
+      (let
+        (
+          (items-remaining (- content-count start-index))
+          (items-to-fetch (if (< items-remaining limited-page-size) 
+                             items-remaining 
+                             limited-page-size))
+        )
+        ;; Build a fixed-size list of content hashes using individual lookups
+        ;; This avoids recursion issues in Clarity
+        (ok (get-content-hash-page author start-index items-to-fetch))
+      )
+    )
+  )
+)
+
+;; Helper to get a page of content hashes without recursion
+;; Limited to maximum 20 items to avoid stack issues
+(define-read-only (get-content-hash-page (author principal) (start-index uint) (count uint))
+  (let
+    (
+      ;; Start with empty list
+      (result (list))
+      
+      ;; Get individual items - limited to 20 max to avoid stack overflow
+      ;; Using individual conditionals instead of recursion
+      (result-1 (match (map-get? author-content-by-index { author: author, index: start-index })
+                  item (unwrap! (as-max-len? (append result (get content-hash item)) u20) result)
+                  result))
+                  
+      (result-2 (if (>= u1 count) 
+                   result-1
+                   (match (map-get? author-content-by-index { author: author, index: (+ start-index u1) })
+                     item (unwrap! (as-max-len? (append result-1 (get content-hash item)) u20) result-1)
+                     result-1)))
+                     
+      (result-3 (if (>= u2 count) 
+                   result-2
+                   (match (map-get? author-content-by-index { author: author, index: (+ start-index u2) })
+                     item (unwrap! (as-max-len? (append result-2 (get content-hash item)) u20) result-2)
+                     result-2)))
+                     
+      (result-4 (if (>= u3 count) 
+                   result-3
+                   (match (map-get? author-content-by-index { author: author, index: (+ start-index u3) })
+                     item (unwrap! (as-max-len? (append result-3 (get content-hash item)) u20) result-3)
+                     result-3)))
+                     
+      (result-5 (if (>= u4 count) 
+                   result-4
+                   (match (map-get? author-content-by-index { author: author, index: (+ start-index u4) })
+                     item (unwrap! (as-max-len? (append result-4 (get content-hash item)) u20) result-4)
+                     result-4)))
+                   
+      ;; Continue for additional items up to 20
+      (result-6 (if (>= u5 count) 
+                   result-5
+                   (match (map-get? author-content-by-index { author: author, index: (+ start-index u5) })
+                     item (unwrap! (as-max-len? (append result-5 (get content-hash item)) u20) result-5)
+                     result-5)))
+                     
+      (result-7 (if (>= u6 count) 
+                   result-6
+                   (match (map-get? author-content-by-index { author: author, index: (+ start-index u6) })
+                     item (unwrap! (as-max-len? (append result-6 (get content-hash item)) u20) result-6)
+                     result-6)))
+                     
+      (result-8 (if (>= u7 count) 
+                   result-7
+                   (match (map-get? author-content-by-index { author: author, index: (+ start-index u7) })
+                     item (unwrap! (as-max-len? (append result-7 (get content-hash item)) u20) result-7)
+                     result-7)))
+                     
+      (result-9 (if (>= u8 count) 
+                   result-8
+                   (match (map-get? author-content-by-index { author: author, index: (+ start-index u8) })
+                     item (unwrap! (as-max-len? (append result-8 (get content-hash item)) u20) result-8)
+                     result-8)))
+                     
+      (result-10 (if (>= u9 count) 
+                   result-9
+                   (match (map-get? author-content-by-index { author: author, index: (+ start-index u9) })
+                     item (unwrap! (as-max-len? (append result-9 (get content-hash item)) u20) result-9)
+                     result-9)))
+                     
+      (result-11 (if (>= u10 count) 
+                   result-10
+                   (match (map-get? author-content-by-index { author: author, index: (+ start-index u10) })
+                     item (unwrap! (as-max-len? (append result-10 (get content-hash item)) u20) result-10)
+                     result-10)))
+                     
+      (result-12 (if (>= u11 count) 
+                   result-11
+                   (match (map-get? author-content-by-index { author: author, index: (+ start-index u11) })
+                     item (unwrap! (as-max-len? (append result-11 (get content-hash item)) u20) result-11)
+                     result-11)))
+                     
+      (result-13 (if (>= u12 count) 
+                   result-12
+                   (match (map-get? author-content-by-index { author: author, index: (+ start-index u12) })
+                     item (unwrap! (as-max-len? (append result-12 (get content-hash item)) u20) result-12)
+                     result-12)))
+                     
+      (result-14 (if (>= u13 count) 
+                   result-13
+                   (match (map-get? author-content-by-index { author: author, index: (+ start-index u13) })
+                     item (unwrap! (as-max-len? (append result-13 (get content-hash item)) u20) result-13)
+                     result-13)))
+                     
+      (result-15 (if (>= u14 count) 
+                   result-14
+                   (match (map-get? author-content-by-index { author: author, index: (+ start-index u14) })
+                     item (unwrap! (as-max-len? (append result-14 (get content-hash item)) u20) result-14)
+                     result-14)))
+                     
+      (result-16 (if (>= u15 count) 
+                   result-15
+                   (match (map-get? author-content-by-index { author: author, index: (+ start-index u15) })
+                     item (unwrap! (as-max-len? (append result-15 (get content-hash item)) u20) result-15)
+                     result-15)))
+                     
+      (result-17 (if (>= u16 count) 
+                   result-16
+                   (match (map-get? author-content-by-index { author: author, index: (+ start-index u16) })
+                     item (unwrap! (as-max-len? (append result-16 (get content-hash item)) u20) result-16)
+                     result-16)))
+                     
+      (result-18 (if (>= u17 count) 
+                   result-17
+                   (match (map-get? author-content-by-index { author: author, index: (+ start-index u17) })
+                     item (unwrap! (as-max-len? (append result-17 (get content-hash item)) u20) result-17)
+                     result-17)))
+                     
+      (result-19 (if (>= u18 count) 
+                   result-18
+                   (match (map-get? author-content-by-index { author: author, index: (+ start-index u18) })
+                     item (unwrap! (as-max-len? (append result-18 (get content-hash item)) u20) result-18)
+                     result-18)))
+                     
+      (result-20 (if (>= u19 count) 
+                   result-19
+                   (match (map-get? author-content-by-index { author: author, index: (+ start-index u19) })
+                     item (unwrap! (as-max-len? (append result-19 (get content-hash item)) u20) result-19)
+                     result-19)))
+    )
+    ;; Return the final result with up to 20 items
+    result-20
+  )
+)


### PR DESCRIPTION
---

# 📌 **Fix: Non-Recursive Pagination for Author Content Retrieval**  

## 🔍 **Summary**  
This PR introduces a fixed non-recursive approach to paginate author content retrieval, preventing potential stack overflow issues in Clarity due to recursion. The solution ensures efficient data fetching while enforcing a maximum page size limit of 20 items per request.

## 🛠️ **Changes Introduced**  
1. **Refactored `get-author-content-paged` function**  
   - Implements pagination using a `page` and `page-size` parameter.  
   - Restricts the page size to a maximum of **20** to prevent excessive memory usage.  
   - Validates the requested page index to avoid out-of-bounds errors.  
   - Retrieves content hashes efficiently using an iterative approach instead of recursion.  

2. **Introduced `get-content-hash-page` helper function**  
   - Fetches a fixed number of content hashes (up to 20) based on the requested page.  
   - Uses individual lookups instead of recursion, ensuring Clarity execution constraints are met.  
   - Constructs the result list dynamically while maintaining strict length limits.  

## 📌 **Why This Change?**  
- Clarity, being a **predictable and decidable** language, has **no recursion** support, which can lead to inefficiencies when handling large datasets.  
- The previous approach relied on recursive function calls, which could exceed Clarity's constraints.  
- This new approach avoids recursion while maintaining pagination capabilities.  

## 🧩 **Implementation Details**  
- **Pagination Calculation:**  
  - Uses `start-index = page * page-size` to determine where to begin fetching.  
  - Ensures `start-index` does not exceed the total content count.  
  - Uses `items-to-fetch = min(remaining-items, page-size)` to get only the required number of results.  

- **Iterative Content Retrieval:**  
  - Looks up individual content records using `map-get?` calls.  
  - Builds a list of content hashes without recursion, ensuring Clarity execution constraints are met.  

## ✅ **Benefits**  
- **Performance Optimization:** Prevents stack overflow risks from recursion.  
- **Scalability:** Supports paginated queries while maintaining Clarity's strict execution constraints.  
- **Reliability:** Ensures correctness by limiting page size and handling edge cases like empty pages.  